### PR TITLE
Title label don't support multiple rows

### DIFF
--- a/RNBlurModalExample/RNViewController.m
+++ b/RNBlurModalExample/RNViewController.m
@@ -61,7 +61,7 @@
         modal = [[RNBlurModalView alloc] initWithView:view];
     }
     else {
-        modal = [[RNBlurModalView alloc] initWithTitle:@"Hello world!" message:@"This is the default modal for RNBlurModalView. Feel free to pass any UIView to it as you wish!"];
+        modal = [[RNBlurModalView alloc] initWithTitle:@"Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world!" message:@"This is the default modal for RNBlurModalView. Feel free to pass any UIView to it as you wish!"];
     }
     [modal show];
 }

--- a/RNBlurModalExample/RNViewController.m
+++ b/RNBlurModalExample/RNViewController.m
@@ -62,6 +62,9 @@
     }
     else {
         modal = [[RNBlurModalView alloc] initWithTitle:@"Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world!" message:@"This is the default modal for RNBlurModalView. Feel free to pass any UIView to it as you wish!"];
+        modal.defaultHideBlock = ^{
+            NSLog(@"Code called after the modal view is hidden");
+        };
     }
     [modal show];
 }

--- a/RNBlurModalView.h
+++ b/RNBlurModalView.h
@@ -36,6 +36,8 @@ extern NSString * const kRNBlurDidHidewNotification;
 @property (assign) CGFloat animationDuration;
 @property (assign) CGFloat animationDelay;
 @property (assign) UIViewAnimationOptions animationOptions;
+@property (nonatomic, copy) void (^defaultHideBlock)(void);
+
 
 - (id)initWithViewController:(UIViewController*)viewController view:(UIView*)view;
 - (id)initWithViewController:(UIViewController*)viewController title:(NSString*)title message:(NSString*)message;

--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -115,6 +115,7 @@ typedef void (^RNBlurCompletion)(void);
     titleLabel.textAlignment = NSTextAlignmentCenter;
     titleLabel.backgroundColor = [UIColor clearColor];
     [titleLabel autoHeight];
+    titleLabel.numberOfLines = 0;
     titleLabel.top = padding;
     [view addSubview:titleLabel];
     

--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -346,7 +346,7 @@ typedef void (^RNBlurCompletion)(void);
 
 
 - (void)hide {
-    [self hideWithDuration:kRNBlurDefaultDuration delay:0 options:kNilOptions completion:NULL];
+    [self hideWithDuration:kRNBlurDefaultDuration delay:0 options:kNilOptions completion:self.defaultHideBlock];
 }
 
 


### PR DESCRIPTION
The title label on the default modal view don't support multiple rows, it was calculating the height correctly but I think the creator forgot to se the number of lines to 0.
