### PR TITLE
Adding accessibility information for automated test frameworks and voice over

### DIFF
--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -517,6 +517,9 @@ typedef void (^RNBlurCompletion)(void);
         closeButtonImage = [self closeButtonImage];
     });
     [self setBackgroundImage:closeButtonImage forState:UIControlStateNormal];
+    self.accessibilityTraits |= UIAccessibilityTraitButton;
+    self.accessibilityLabel = NSLocalizedString(@"Dismiss Alert", @"Dismiss Alert Close Button");
+    self.accessibilityHint = NSLocalizedString(@"Dismisses this alert.",@"Dismiss Alert close button hint");
     return self;
 }
 


### PR DESCRIPTION
Adding accessibility traits to the close button.  Adding this will help with automated test frameworks as well as improving user experience when using VoiceOver.
