### PR TITLE
Using new API for screenshot

### DIFF
--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -605,7 +605,11 @@ typedef void (^RNBlurCompletion)(void);
 
 - (UIImage*)screenshot {
     UIGraphicsBeginImageContext(self.bounds.size);
-    [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+    if( [self respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)] ){
+        [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:YES];
+    }else{
+        [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+    }
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     


### PR DESCRIPTION
When using iOS 7 with standard navigation bars and toolbars, renderInContext: doesn't capture the content. Must use new iOS 7 API for this.
