### PR TITLE
Content view position + AppleDoc

### DIFF
--- a/RNBlurModalView.h
+++ b/RNBlurModalView.h
@@ -26,7 +26,9 @@
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 
+/** The string for the NSNotificationCenter. Will be called when the window is shown */
 extern NSString * const kRNBlurDidShowNotification;
+/** The string for the NSNotificationCenter. Will be called when the window is hidden */
 extern NSString * const kRNBlurDidHidewNotification;
 
 /**
@@ -42,14 +44,22 @@ typedef NS_ENUM(NSUInteger, RNBlurModalViewAlignment){
     RNBlurModalViewAlignmentBottom      = 2,
 };
 
+/**
+ * A Modal view to hold content, blurring all the background
+ */
 @interface RNBlurModalView : UIView
 
+/** Tells the user if the window is showing. */
 @property (assign, readonly) BOOL isVisible;
-
+/** Specifies the duration of the animation. */
 @property (assign) CGFloat animationDuration;
+/** Specifies the delay before the animation starts. */
 @property (assign) CGFloat animationDelay;
+/** Animation options */
 @property (assign) UIViewAnimationOptions animationOptions;
+/** Changes the position of the button from the left (FALSE) to the right (TRUE) */
 @property (assign) BOOL dismissButtonRight;
+/** Block called when the view is hidden */
 @property (nonatomic, copy) void (^defaultHideBlock)(void);
 /** Alignment of the content view (left, center or right) */
 @property (assign, nonatomic) RNBlurModalViewAlignment horizontalAlignment;
@@ -62,20 +72,87 @@ typedef NS_ENUM(NSUInteger, RNBlurModalViewAlignment){
  * if VerticalAlignment == NSBlurModalViewAlignmentCenter it will be ignored */
 @property (assign, nonatomic) CGFloat verticalSpacing;
 
+/**
+ * Constructor with parent view controller and custom content
+ * @param viewController The parent view controller
+ * @param view The content to show
+ * @return self or nil if something went wrong
+ */
 - (id)initWithViewController:(UIViewController*)viewController view:(UIView*)view;
+
+/**
+ * Constructor with parent view controller. It creates a view with text.
+ * @param viewController The parent view controller
+ * @param title The title of the window
+ * @param message The message to show to the user
+ * @return self or nil if something went wrong
+ */
 - (id)initWithViewController:(UIViewController*)viewController title:(NSString*)title message:(NSString*)message;
+
+/**
+ * Constructor with parent view and custom content
+ * @param parentView The parent view
+ * @param view The content to show
+ * @return self or nil if something went wrong
+ */
 - (id)initWithParentView:(UIView*)parentView view:(UIView*)view;
+
+/**
+ * Constructor with parent view. It creates a view with text.
+ * @param parentView The parent view
+ * @param title The title of the window
+ * @param message The message to show to the user
+ * @return self or nil if something went wrong
+ */
 - (id)initWithParentView:(UIView*)parentView title:(NSString*)title message:(NSString*)message;
+
+/**
+ * Constructor with custom content
+ * @param view The content to show
+ * @return self or nil if something went wrong
+ */
 - (id)initWithView:(UIView*)view;
+
+/**
+ * Constructor with strings. It will create a view with a message
+ * @param title The title of the window
+ * @param message The message to show to the user
+ * @return self or nil if something went wrong
+ */
 - (id)initWithTitle:(NSString*)title message:(NSString*)message;
 
+/**
+ * Shows the window
+ */
 - (void)show;
+
+/**
+ * Shows the window with a certain animation configuration
+ * @param duration The duration of the animation
+ * @param delay The delay of the animation
+ * @param options The animation options
+ * @param completion The action to perform at the end of the animation
+ */
 - (void)showWithDuration:(CGFloat)duration delay:(NSTimeInterval)delay options:(UIViewAnimationOptions)options completion:(void (^)(void))completion;
 
+/**
+ * Hides the window
+ */
 - (void)hide;
+
+/**
+ * Hides the control with a certain animation configuration
+ * @param duration The duration of the animation
+ * @param delay The delay of the animation
+ * @param options The animation options
+ * @param completion The action to perform at the end of the animation
+ */
 - (void)hideWithDuration:(CGFloat)duration delay:(NSTimeInterval)delay options:(UIViewAnimationOptions)options completion:(void (^)(void))completion;
 
+/**
+ * Hides the close button in the top corner
+ * @param hide TRUE if you want to hide the close button, or FALSE if you want to unhide it.
+ */
 -(void)hideCloseButton:(BOOL)hide;
-
 
 @end

--- a/RNBlurModalView.h
+++ b/RNBlurModalView.h
@@ -29,6 +29,19 @@
 extern NSString * const kRNBlurDidShowNotification;
 extern NSString * const kRNBlurDidHidewNotification;
 
+/**
+ * Enum for the alignment of the content.
+ * The view can be aligned to the borders (top, bottom, left or right),
+ * or can be centered (horizontally or vertically, or both)
+ */
+typedef NS_ENUM(NSUInteger, RNBlurModalViewAlignment){
+    RNBlurModalViewAlignmentLeft        = 0,
+    RNBlurModalViewAlignmentTop         = 0,
+    RNBlurModalViewAlignmentCenter      = 1,
+    RNBlurModalViewAlignmentRight       = 2,
+    RNBlurModalViewAlignmentBottom      = 2,
+};
+
 @interface RNBlurModalView : UIView
 
 @property (assign, readonly) BOOL isVisible;
@@ -38,6 +51,16 @@ extern NSString * const kRNBlurDidHidewNotification;
 @property (assign) UIViewAnimationOptions animationOptions;
 @property (assign) BOOL dismissButtonRight;
 @property (nonatomic, copy) void (^defaultHideBlock)(void);
+/** Alignment of the content view (left, center or right) */
+@property (assign, nonatomic) RNBlurModalViewAlignment horizontalAlignment;
+/** Alignment of the content view (top, center or bottom) */
+@property (assign, nonatomic) RNBlurModalViewAlignment verticalAlignment;
+/** Space between the content view and the screen border.
+ * if horizontalAlignment == NSBlurModalViewAlignmentCenter it will be ignored */
+@property (assign, nonatomic) CGFloat horizontalSpacing;
+/** Space between the content view and the screen border.
+ * if VerticalAlignment == NSBlurModalViewAlignmentCenter it will be ignored */
+@property (assign, nonatomic) CGFloat verticalSpacing;
 
 - (id)initWithViewController:(UIViewController*)viewController view:(UIView*)view;
 - (id)initWithViewController:(UIViewController*)viewController title:(NSString*)title message:(NSString*)message;

--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -93,6 +93,11 @@ typedef void (^RNBlurCompletion)(void);
     RNBlurCompletion _completion;
 }
 
+@synthesize horizontalAlignment = _horizontalAlignment;
+@synthesize verticalAlignment   = _verticalAlignment;
+@synthesize horizontalSpacing   = _horizontalSpacing;
+@synthesize verticalSpacing     = _verticalSpacing;
+
 + (UIView*)generateModalViewWithTitle:(NSString*)title message:(NSString*)message {
     CGFloat defaultWidth = 280.f;
     CGRect frame = CGRectMake(0, 0, defaultWidth, 0);
@@ -139,6 +144,25 @@ typedef void (^RNBlurCompletion)(void);
     return view;
 }
 
+- (void)setHorizontalAlignment:(RNBlurModalViewAlignment)horizontalAlignment {
+    _horizontalAlignment = horizontalAlignment;
+    _contentView.center = [self getContentViewCenter];
+}
+
+- (void)setVerticalAlignment:(RNBlurModalViewAlignment)verticalAlignment {
+    _verticalAlignment = verticalAlignment;
+    _contentView.center = [self getContentViewCenter];
+}
+
+- (void)setHorizontalSpacing:(CGFloat)horizontalSpacing {
+    _horizontalSpacing = horizontalSpacing;
+    _contentView.center = [self getContentViewCenter];
+}
+
+- (void)setVerticalSpacing:(CGFloat)verticalSpacing {
+    _verticalSpacing = verticalSpacing;
+    _contentView.center = [self getContentViewCenter];
+}
 
 - (id)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
@@ -156,6 +180,10 @@ typedef void (^RNBlurCompletion)(void);
                                   UIViewAutoresizingFlexibleHeight |
                                   UIViewAutoresizingFlexibleLeftMargin |
                                   UIViewAutoresizingFlexibleTopMargin);
+        // Center the view:
+        self.horizontalAlignment = RNBlurModalViewAlignmentCenter;
+        self.verticalAlignment = RNBlurModalViewAlignmentCenter;
+        self.horizontalSpacing = self.verticalSpacing = 20.0f;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChangeNotification:) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
     }
@@ -168,7 +196,7 @@ typedef void (^RNBlurCompletion)(void);
     if (self = [self initWithFrame:CGRectMake(0, 0, viewController.view.width, viewController.view.height)]) {
         [self addSubview:view];
         _contentView = view;
-        _contentView.center = CGPointMake(CGRectGetMidX(self.frame), CGRectGetMidY(self.frame));
+        _contentView.center = [self getContentViewCenter];
         _controller = viewController;
         _parentView = nil;
         _contentView.clipsToBounds = YES;
@@ -193,7 +221,7 @@ typedef void (^RNBlurCompletion)(void);
     if (self = [self initWithFrame:CGRectMake(0, 0, parentView.width, parentView.height)]) {
         [self addSubview:view];
         _contentView = view;
-        _contentView.center = CGPointMake(CGRectGetMidX(self.frame), CGRectGetMidY(self.frame));
+        _contentView.center = [self getContentViewCenter];
         _controller = nil;
         _parentView = parentView;
         _contentView.clipsToBounds = YES;
@@ -236,6 +264,38 @@ typedef void (^RNBlurCompletion)(void);
     _dismissButton.center = CGPointMake(centerX, _contentView.top);
 }
 
+- (CGPoint)getContentViewCenter {
+    CGFloat x = 0.0f, y=0.0f;
+    CGFloat w = _contentView.frame.size.width;
+    CGFloat h = _contentView.frame.size.height;
+    // Horizontal position
+    switch (self.horizontalAlignment){
+        case RNBlurModalViewAlignmentLeft:
+            x = CGRectGetMinX(self.frame) + w/2 + self.horizontalSpacing;
+            break;
+        case RNBlurModalViewAlignmentRight:
+            x = CGRectGetMaxX(self.frame) - w/2 - self.horizontalSpacing;
+            break;
+        case RNBlurModalViewAlignmentCenter:
+            x = CGRectGetMidX(self.frame);
+            break;
+    }
+    // Vertical position
+    switch (self.verticalAlignment){
+        case RNBlurModalViewAlignmentTop:
+            y = CGRectGetMinY(self.frame) + h/2 + self.verticalSpacing;
+            break;
+        case RNBlurModalViewAlignmentBottom:
+            y = CGRectGetMaxY(self.frame) - h/2 - self.verticalSpacing;
+            break;
+        case RNBlurModalViewAlignmentCenter:
+            y = CGRectGetMidY(self.frame);
+            break;
+    }
+    CGPoint center = CGPointMake(x, y);
+    return center;
+}
+
 - (void)willMoveToSuperview:(UIView *)newSuperview {
     [super willMoveToSuperview:newSuperview];
     if (newSuperview) {
@@ -273,7 +333,7 @@ typedef void (^RNBlurCompletion)(void);
     
     self.hidden = NO;
 
-    _contentView.center = CGPointMake(CGRectGetMidX(self.frame), CGRectGetMidY(self.frame));
+    _contentView.center = [self getContentViewCenter];
     _dismissButton.center = _contentView.origin;
 }
 


### PR DESCRIPTION
In most of the cases you want to see the modal view in the center, but in some cases you want it to be somewhere else. For example if the view has a textfield, you want it to be in the top, so the keyboard doesn't cover it.
For that purpose I have added properties to define the alignment (horizontal+vertical) of the view. By default it will be centered, but you can change it by just changing the values of alignment and spacing.

Also, I have added comments in the .h file, just to suppress the warnings from the AppleDoc compiler. The code is self explanatory I think, but AppleDoc is a good feature to have in XCode anyway.
