### PR TITLE
Added method for moving close button

### DIFF
--- a/RNBlurModalView.h
+++ b/RNBlurModalView.h
@@ -52,7 +52,8 @@ extern NSString * const kRNBlurDidHidewNotification;
 - (void)hide;
 - (void)hideWithDuration:(CGFloat)duration delay:(NSTimeInterval)delay options:(UIViewAnimationOptions)options completion:(void (^)(void))completion;
 
--(void)hideCloseButton:(BOOL)hide;
+- (void)moveCloseButton:(CGPoint)point;
+- (void)hideCloseButton:(BOOL)hide;
 
 
 @end

--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -379,7 +379,11 @@ typedef void (^RNBlurCompletion)(void);
     }
 }
 
--(void)hideCloseButton:(BOOL)hide {
+- (void)moveCloseButton:(CGPoint)point {
+    _dismissButton.frame = CGRectMake(point.x, point.y, _dismissButton.frame.size.width, _dismissButton.frame.size.height);
+}
+
+- (void)hideCloseButton:(BOOL)hide {
     [_dismissButton setHidden:hide];
 }
 


### PR DESCRIPTION
This method should be called when custom view inside RNBlurModalView
gets resized or moved. Called with argument - point of the new top left corner,
in order to keep the close button where it should be. Otherwise the button does not move along with the view.
