### PR TITLE
Fix not center aligned issue in landscape mode for both iOS7 and iOS8

### DIFF
--- a/RNBlurModalView.m
+++ b/RNBlurModalView.m
@@ -134,8 +134,6 @@ typedef void (^RNBlurCompletion)(void);
     
     view.height = messageLabel.bottom + padding;
     
-    view.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin;
-    
     return view;
 }
 
@@ -168,7 +166,7 @@ typedef void (^RNBlurCompletion)(void);
     if (self = [self initWithFrame:CGRectMake(0, 0, viewController.view.width, viewController.view.height)]) {
         [self addSubview:view];
         _contentView = view;
-        _contentView.center = CGPointMake(CGRectGetMidX(self.frame), CGRectGetMidY(self.frame));
+        _contentView.center = CGPointMake(CGRectGetMidX(viewController.view.bounds), CGRectGetMidY(viewController.view.bounds));
         _controller = viewController;
         _parentView = nil;
         _contentView.clipsToBounds = YES;
@@ -193,7 +191,7 @@ typedef void (^RNBlurCompletion)(void);
     if (self = [self initWithFrame:CGRectMake(0, 0, parentView.width, parentView.height)]) {
         [self addSubview:view];
         _contentView = view;
-        _contentView.center = CGPointMake(CGRectGetMidX(self.frame), CGRectGetMidY(self.frame));
+        _contentView.center = CGPointMake(CGRectGetMidX(parentView.bounds), CGRectGetMidY(parentView.bounds));
         _controller = nil;
         _parentView = parentView;
         _contentView.clipsToBounds = YES;


### PR DESCRIPTION
Hi @rnystrom 

This commit resolves #45 .
The problem can be seen in these screenshots for landscape mode (iOS7.1) in iPad.
Pull requests #9 resolved similar issue but the solution only works in iOS8. In iOS7.1 for example the result is what you can see in these screenshots:

![rnblurmodalviewpullreq1](https://cloud.githubusercontent.com/assets/4446420/4779577/98158cb4-5c38-11e4-8450-af3292aec5d8.png)

![rnblurmodalviewpullreq2](https://cloud.githubusercontent.com/assets/4446420/4779578/9e0c1eee-5c38-11e4-81d3-e6e41f9dfc81.png)

The problem is based on difference between bounds and frames values in portrait and landscape mode.
We should use bounds to perform any calculation as it gives us the correct values independent of our device orientation.
Calculation for _contentView.center should be based on viewController.view.bounds and parentView.bounds.

Regards,
Nima Azimi
